### PR TITLE
Implemented a section header system.

### DIFF
--- a/src/igwmod/gui/GuiWiki.java
+++ b/src/igwmod/gui/GuiWiki.java
@@ -3,20 +3,10 @@ package igwmod.gui;
 import igwmod.InfoSupplier;
 import igwmod.TickHandler;
 import igwmod.WikiUtils;
-import igwmod.api.BlockWikiEvent;
-import igwmod.api.EntityWikiEvent;
-import igwmod.api.ItemWikiEvent;
-import igwmod.api.PageChangeEvent;
-import igwmod.api.WikiRegistry;
+import igwmod.api.*;
 import igwmod.gui.tabs.IWikiTab;
 import igwmod.lib.Textures;
 import igwmod.lib.Util;
-
-import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
@@ -31,10 +21,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Derived from Vanilla's GuiContainerCreative
@@ -275,7 +269,9 @@ public class GuiWiki extends GuiContainer{
         if(pages != null) {
             List<Integer> matchingIndexes = new ArrayList<Integer>();
             for(int i = 0; i < pages.size(); i++) {
-                if(pages.get(i).getName().toLowerCase().contains(searchField.getText().toLowerCase())) {
+                if(searchField.getText().toLowerCase().equals("")){
+                    matchingIndexes.add(i);
+                } else if (pages.get(i).getName().toLowerCase().contains(searchField.getText().toLowerCase()) && !(pages.get(i) instanceof LocatedSectionString) && !(pages.get(i) instanceof LocatedSpacer)) {
                     matchingIndexes.add(i);
                 }
             }

--- a/src/igwmod/gui/LocatedSectionString.java
+++ b/src/igwmod/gui/LocatedSectionString.java
@@ -1,0 +1,38 @@
+package igwmod.gui;
+
+import net.minecraft.util.EnumChatFormatting;
+
+/**
+ * Created by K-4U on 17-7-2015.
+ */
+public class LocatedSectionString extends LocatedString {
+    private String beforeFormat;
+    /**
+     * A constructor for unlinked located strings. You can specify a color.
+     * @param string
+     * @param x
+     * @param y
+     * @param color
+     * @param shadow
+     */
+    public LocatedSectionString(String string, int x, int y, int color, boolean shadow){
+        super(EnumChatFormatting.BOLD + string, x, y, color, shadow);
+        beforeFormat = string;
+    }
+    /**
+     * A constructor for unlinked located strings.
+     * @param string
+     * @param x
+     * @param y
+     * @param shadow
+     */
+    public LocatedSectionString(String string, int x, int y, boolean shadow){
+        super(EnumChatFormatting.BOLD + string, x, y, 0, shadow);
+        beforeFormat = string;
+    }
+
+    @Override
+    public String getName(){
+        return beforeFormat;
+    }
+}

--- a/src/igwmod/gui/LocatedSpacer.java
+++ b/src/igwmod/gui/LocatedSpacer.java
@@ -1,0 +1,75 @@
+package igwmod.gui;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+
+import java.awt.*;
+
+public class LocatedSpacer extends Gui implements IPageLink {
+    protected static FontRenderer fontRenderer = FMLClientHandler.instance().getClient().fontRenderer;
+
+    private int x;
+    private int y;
+
+    public LocatedSpacer(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public String getName() {
+        return "-";
+    }
+
+    @Override
+    public String getLinkAddress() {
+        return null;
+    }
+
+    @Override
+    public boolean onMouseClick(GuiWiki gui, int x, int y) {
+        return false;
+    }
+
+    @Override
+    public Rectangle getReservedSpace() {
+        return new Rectangle(x, y, 10, fontRenderer.FONT_HEIGHT);
+    }
+
+    @Override
+    public void renderBackground(GuiWiki gui, int mouseX, int mouseY) {
+        //Honestly, the spacer doesn't really require a renderer, but it's here.
+
+    }
+
+    @Override
+    public void renderForeground(GuiWiki gui, int mouseX, int mouseY) {
+
+    }
+
+    @Override
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    @Override
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getHeight() {
+        return fontRenderer.FONT_HEIGHT;
+    }
+}

--- a/src/igwmod/gui/tabs/BaseWikiTab.java
+++ b/src/igwmod/gui/tabs/BaseWikiTab.java
@@ -1,16 +1,12 @@
 package igwmod.gui.tabs;
 
-import igwmod.gui.GuiWiki;
-import igwmod.gui.IPageLink;
-import igwmod.gui.IReservedSpace;
-import igwmod.gui.LocatedString;
+import igwmod.gui.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class BaseWikiTab implements IWikiTab{
     protected List<String> pageEntries = new ArrayList<String>();
-    private final List<Integer> lineSkips = new ArrayList<Integer>();
 
     @Override
     public List<IReservedSpace> getReservedSpaces(){
@@ -22,22 +18,34 @@ public abstract class BaseWikiTab implements IWikiTab{
         List<IPageLink> pages = new ArrayList<IPageLink>();
         if(pageIndexes == null) {
             for(int i = 0; i < pageEntries.size(); i++) {
-                pages.add(new LocatedString(getPageName(pageEntries.get(i)), 80, 64 + 11 * i, false, getPageLocation(pageEntries.get(i))));
+                if(pageEntries.get(i).startsWith("#")) {
+                    pages.add(new LocatedSectionString(getPageName(pageEntries.get(i)), 80, 64 + 11 * i, false));
+                } else if(pageEntries.get(i).equals("-")){
+                    pages.add(new LocatedSpacer(80, 64 + 11 * i));
+                } else {
+                    pages.add(new LocatedString(getPageName(pageEntries.get(i)), 80, 64 + 11 * i, false, getPageLocation(pageEntries.get(i))));
+                }
             }
         } else {
-            int skipOffset = 0;
             for(int i = 0; i < pageIndexes.length; i++) {
-                if(pageIndexes.length == pageEntries.size() && lineSkips.contains(i)) {
-                    skipOffset += 11;
+                if(pageEntries.get(pageIndexes[i]).startsWith("#")) {
+                    pages.add(new LocatedSectionString(getPageName(pageEntries.get(pageIndexes[i])), 80, 64 + 11 * i, false).capTextWidth(pagesPerTab() > pageIndexes.length ? 100 : 77));
+                } else if(pageEntries.get(pageIndexes[i]).startsWith("-")){
+                    pages.add(new LocatedSpacer(80, 64 + 11 * i));
+                } else {
+                    pages.add(new LocatedString(getPageName(pageEntries.get(pageIndexes[i])), 80, 64 + 11 * i, false, getPageLocation(pageEntries.get(pageIndexes[i]))).capTextWidth(pagesPerTab() > pageIndexes.length ? 100 : 77));
                 }
-                pages.add(new LocatedString(getPageName(pageEntries.get(pageIndexes[i])), 80, 64 + 11 * i + skipOffset, false, getPageLocation(pageEntries.get(pageIndexes[i]))).capTextWidth(pagesPerTab() > pageIndexes.length ? 100 : 77));
             }
         }
         return pages;
     }
 
     protected void skipLine(){
-        lineSkips.add(pageEntries.size());
+        pageEntries.add("-");
+    }
+
+    protected void addSectionHeader(String header){
+        pageEntries.add("#" + header);
     }
 
     @Override


### PR DESCRIPTION
Only thing required to be added to the implementing mod is:
`if(pageEntry.startsWith("#")) return I18n.format(ModInfo.LID + ".wiki.section." + pageEntry.replace("#",""));` which should be implemented in the `getPageName` method, in the custom tab.

I have unfortunately changed the imports around. But this is probably fixed with a single keypress in eclipse.