### PR TITLE
Fixes some crashes, Improves support for certain blocks and items in recipes

### DIFF
--- a/src/igwmod/gui/ContainerBlockWiki.java
+++ b/src/igwmod/gui/ContainerBlockWiki.java
@@ -31,7 +31,11 @@ class ContainerBlockWiki extends Container{
                     public boolean isItemValid(ItemStack par1ItemStack){
                         return false;
                     }
-                });
+                });                
+                if(stack.stack.getItemDamage() == 32767)//TODO better way to handle wildcard value.
+                {
+                    stack.stack.setItemDamage(0);
+                }
                 inventory.setInventorySlotContents(curSlot++, stack.stack);
             }
         }

--- a/src/igwmod/gui/GuiWiki.java
+++ b/src/igwmod/gui/GuiWiki.java
@@ -664,7 +664,7 @@ public class GuiWiki extends GuiContainer{
                 } else {
                     boolean oldSetting = mc.gameSettings.fancyGraphics;
                     mc.gameSettings.fancyGraphics = true;
-                    renderRotatingBlockIntoGUI(this, drawingStack, 12, 26, 1.2F);
+                    renderRotatingBlockIntoGUI(this, drawingStack, 12, 20, 1.2F);
                     mc.gameSettings.fancyGraphics = oldSetting;
                 }
             }

--- a/src/igwmod/gui/tabs/BlockAndItemWikiTab.java
+++ b/src/igwmod/gui/tabs/BlockAndItemWikiTab.java
@@ -22,12 +22,7 @@ import net.minecraft.item.ItemStack;
 import org.lwjgl.opengl.GL11;
 
 public class BlockAndItemWikiTab implements IWikiTab{
-    public static RenderItem itemRenderer;
     private static ItemStack drawingStack;
-
-    static {
-        itemRenderer = Minecraft.getMinecraft().getRenderItem();
-    }
 
     @Override
     public String getName(){
@@ -88,7 +83,7 @@ public class BlockAndItemWikiTab implements IWikiTab{
                 GL11.glPushMatrix();
                 GL11.glTranslated(49, 20, 0);
                 GL11.glScaled(2.2, 2.2, 2.2);
-                itemRenderer.renderItemAndEffectIntoGUI(drawingStack, 0, 0);
+                Minecraft.getMinecraft().getRenderItem().renderItemAndEffectIntoGUI(drawingStack, 0, 0);
                 GL11.glPopMatrix();
             }
         }

--- a/src/igwmod/recipeintegration/IntegratorCraftingRecipe.java
+++ b/src/igwmod/recipeintegration/IntegratorCraftingRecipe.java
@@ -90,7 +90,7 @@ public class IntegratorCraftingRecipe implements IRecipeIntegrator{
                 }
             }
             locatedStacks.add(new LocatedStack(recipe.getRecipeOutput(), x + RESULT_STACK_X_OFFSET, y + RESULT_STACK_Y_OFFSET));
-            locatedStrings.add(new LocatedString(I18n.format("igwmod.gui.crafting.shaped"), x + 60, y + 10, 0xFF000000, false));
+            locatedStrings.add(new LocatedString(I18n.format("igwmod.gui.crafting.shaped"), x * 2 + 120, y * 2 + 10, 0xFF000000, false));
         } else if(recipeEvent.recipe instanceof ShapedOreRecipe) {
             ShapedOreRecipe recipe = (ShapedOreRecipe)recipeEvent.recipe;
             int recipeHeight = 0;


### PR DESCRIPTION
These are the primary changes I had made in my 1.8.8 update for IGW-mod.

The addition to ContainerBlockWiki fixes some problems with rendering
items such as buttons into guis from auto-retrieved recipes.  It also
fixes issues with wildcard values, but a better way to handle this would
probably be needed later.

GuiWiki change is to fix a strange offset bug of some rendered tab items
which appeared in the 1.8 update.

The change to BlockAndItemWikiTab fixes a crash due to the Minecraft
RenderItem being null when that class is first referenced.

the change in IntegratorCraftingRecipe moves the text to the correct
spot.