### PR TITLE
Null ItemStack fixes

### DIFF
--- a/src/igwmod/ClientProxy.java
+++ b/src/igwmod/ClientProxy.java
@@ -100,7 +100,7 @@ public class ClientProxy implements IProxy{
         }
 
         for(ItemStack stack : allCreativeStacks) {
-            if(stack != null && stack.getItem() != null && Item.REGISTRY.getNameForObject(stack.getItem()) != null) {
+            if(!stack.isEmpty() && stack.getItem() != null && Item.REGISTRY.getNameForObject(stack.getItem()) != null) {
                 String modid = Paths.MOD_ID.toLowerCase();
                 ResourceLocation id = Item.REGISTRY.getNameForObject(stack.getItem());
                 if(id != null && id.getResourceDomain() != null) modid = id.getResourceDomain().toLowerCase();

--- a/src/igwmod/TickHandler.java
+++ b/src/igwmod/TickHandler.java
@@ -89,7 +89,7 @@ public class TickHandler{
                 IBlockState blockState = world.getBlockState(coordHovered);
                 if(blockState != null) {
                     ItemStack idPicked = blockState.getBlock().getPickBlock(blockState, FMLClientHandler.instance().getClient().objectMouseOver, world, coordHovered, FMLClientHandler.instance().getClientPlayerEntity());
-                    return (idPicked != null ? idPicked : new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState))).getDisplayName(); //TODO test blockState.getBlock().getDamage()
+                    return (!idPicked.isEmpty() ? idPicked : new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState))).getDisplayName(); //TODO test blockState.getBlock().getDamage()
                 }
             } catch(Throwable e) {}
             return TextFormatting.RED + "<ERROR>";

--- a/src/igwmod/WikiUtils.java
+++ b/src/igwmod/WikiUtils.java
@@ -35,14 +35,14 @@ public class WikiUtils{
             }
         }
         String[] splitName = name.contains("#") ? name.split("#") : new String[]{name};
-        ItemStack stack = unlocMap.get(splitName[0]);
-        if(stack != null) {
+        ItemStack stack = unlocMap.getOrDefault(splitName[0], ItemStack.EMPTY);
+        if(!stack.isEmpty()) {
             stack = stack.copy();
             //            if(splitName.length > 1) stack.stackSize = Integer.parseInt(splitName[1]);
             if(splitName.length > 1) stack.setCount(Integer.parseInt(splitName[1]));
             return stack;
         } else {
-            return null;
+            return ItemStack.EMPTY;
         }
     }
 

--- a/src/igwmod/api/BlockWikiEvent.java
+++ b/src/igwmod/api/BlockWikiEvent.java
@@ -26,6 +26,6 @@ public class BlockWikiEvent extends WorldEvent{
         try {
             itemStackPicked = blockState.getBlock().getPickBlock(blockState, FMLClientHandler.instance().getClient().objectMouseOver, world, pos, FMLClientHandler.instance().getClientPlayerEntity());
         } catch(Throwable e) {}//FMP parts have the habit to throw a ClassCastException.
-        drawnStack = itemStackPicked != null ? itemStackPicked : new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
+        drawnStack = !itemStackPicked.isEmpty() ? itemStackPicked : new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
     }
 }

--- a/src/igwmod/api/WikiRegistry.java
+++ b/src/igwmod/api/WikiRegistry.java
@@ -40,7 +40,7 @@ public class WikiRegistry{
     }
 
     public static void registerBlockAndItemPageEntry(ItemStack stack){
-        if(stack == null || stack.getItem() == null) throw new IllegalArgumentException("Can't register null items");
+        if(stack.isEmpty() || stack.getItem() == null) throw new IllegalArgumentException("Can't register null items");
         registerBlockAndItemPageEntry(stack, stack.getUnlocalizedName().replace("tile.", "block/").replace("item.", "item/"));
     }
 

--- a/src/igwmod/gui/ContainerBlockWiki.java
+++ b/src/igwmod/gui/ContainerBlockWiki.java
@@ -64,7 +64,7 @@ class ContainerBlockWiki extends Container{
      */
     @Override
     public ItemStack transferStackInSlot(EntityPlayer par1EntityPlayer, int par2){
-        return null;
+        return ItemStack.EMPTY;
     }
 
     @Override

--- a/src/igwmod/gui/GuiWiki.java
+++ b/src/igwmod/gui/GuiWiki.java
@@ -255,7 +255,7 @@ public class GuiWiki extends GuiContainer{
         BrowseHistory.updateHistory(currentPageScroll);
         if(metadata.length == 0) {
             ItemStack displayedStack = WikiUtils.getStackFromName(file);
-            if(displayedStack != null) metadata = new Object[]{displayedStack};
+            if(!displayedStack.isEmpty()) metadata = new Object[]{displayedStack};
         }
         currentFile = file;
         IWikiTab tab = getTabForPage(currentFile);

--- a/src/igwmod/gui/tabs/BlockAndItemWikiTab.java
+++ b/src/igwmod/gui/tabs/BlockAndItemWikiTab.java
@@ -72,7 +72,7 @@ public class BlockAndItemWikiTab implements IWikiTab{
 
     @Override
     public void renderForeground(GuiWiki gui, int mouseX, int mouseY){
-        if(drawingStack != null) {
+        if(!drawingStack.isEmpty()) {
             GlStateManager.enableLighting();
             RenderHelper.enableGUIStandardItemLighting();
             if(drawingStack.getItem() instanceof ItemBlock) {

--- a/src/igwmod/gui/tabs/IWikiTab.java
+++ b/src/igwmod/gui/tabs/IWikiTab.java
@@ -17,7 +17,7 @@ public interface IWikiTab{
 
     /**
      * Will be called by the GUI to render the tab. The render matrix will already be translated dependant on where this tab is.
-     * @return When you return an ItemStack, this stack will be drawn rotating. Returning null is valid, nothing will be drawn (you will).
+     * @return When you return an ItemStack, this stack will be drawn rotating. Returning ItemStack.EMPTY is valid, nothing will be drawn (you will).
      */
     public ItemStack renderTabIcon(GuiWiki gui);
 

--- a/src/igwmod/gui/tabs/ServerWikiTab.java
+++ b/src/igwmod/gui/tabs/ServerWikiTab.java
@@ -62,7 +62,7 @@ public class ServerWikiTab extends BaseWikiTab{
 
     @Override
     public ItemStack renderTabIcon(GuiWiki gui){
-        if(iconStack != null) {
+        if(!iconStack.isEmpty()) {
             return iconStack;
         } else {
             GL11.glPushMatrix();

--- a/src/igwmod/recipeintegration/IntegratorCraftingRecipe.java
+++ b/src/igwmod/recipeintegration/IntegratorCraftingRecipe.java
@@ -109,7 +109,7 @@ public class IntegratorCraftingRecipe implements IRecipeIntegrator{
                     if(ingredient.getMatchingStacks().length > 0) {
                         ItemStack ingredientStack = ingredient.getMatchingStacks()[0];
                         //ingredient instanceof ItemStack ? (ItemStack)ingredient : ((List<ItemStack>)ingredient).get(0);
-                        if(ingredientStack != null) {
+                        if(!ingredientStack.isEmpty()) {
                             locatedStacks.add(new LocatedStack(ingredientStack, x + STACKS_X_OFFSET + j * 18, y + STACKS_Y_OFFSET + i * 18));
                         }
                     }
@@ -124,7 +124,7 @@ public class IntegratorCraftingRecipe implements IRecipeIntegrator{
                     if(i * 3 + j < recipe.recipeItems.size()) {
                         Ingredient ingredient = recipe.recipeItems.get(i * 3 + j);
                         ItemStack ingredientStack = ingredient.getMatchingStacks()[0];
-                        if(ingredientStack != null) {
+                        if(!ingredientStack.isEmpty()) {
                             locatedStacks.add(new LocatedStack(ingredientStack, x + STACKS_X_OFFSET + j * 18, y + STACKS_Y_OFFSET + i * 18));
                         }
                     }
@@ -141,7 +141,7 @@ public class IntegratorCraftingRecipe implements IRecipeIntegrator{
                         if(ingredient != null) {
                             ItemStack ingredientStack = ingredient.getMatchingStacks()[0];
                             //ingredient instanceof ItemStack ? (ItemStack)ingredient : ((List<ItemStack>)ingredient).get(0);
-                            if(ingredientStack != null) {
+                            if(!ingredientStack.isEmpty()) {
                                 locatedStacks.add(new LocatedStack(ingredientStack, x + STACKS_X_OFFSET + j * 18, y + STACKS_Y_OFFSET + i * 18));
                             }
                         }
@@ -171,13 +171,13 @@ public class IntegratorCraftingRecipe implements IRecipeIntegrator{
         for(int i = 0; i < 3; i++) {
             for(int j = 0; j < 3; j++) {
                 ItemStack ingredientStack = ingredientMap.get(ingredients[i].substring(j, j + 1));
-                if(ingredientStack != null) {
+                if(!ingredientStack.isEmpty()) {
                     locatedStacks.add(new LocatedStack(ingredientStack, x + STACKS_X_OFFSET + j * 18, y + STACKS_Y_OFFSET + i * 18));
                 }
             }
         }
         ItemStack resultStack = WikiUtils.getStackFromName(result);
-        if(resultStack != null) {
+        if(!resultStack.isEmpty()) {
             locatedStacks.add(new LocatedStack(resultStack, x + RESULT_STACK_X_OFFSET, y + RESULT_STACK_Y_OFFSET));
         }
     }

--- a/src/igwmod/recipeintegration/IntegratorFurnace.java
+++ b/src/igwmod/recipeintegration/IntegratorFurnace.java
@@ -45,12 +45,12 @@ public class IntegratorFurnace implements IRecipeIntegrator{
         locatedTextures.add(new LocatedTexture(TextureSupplier.getTexture(Paths.MOD_ID_WITH_COLON + "textures/GuiFurnace.png"), x, y, (int)(82 / GuiWiki.TEXT_SCALE), (int)(54 / GuiWiki.TEXT_SCALE)));
         x = (int)(x * GuiWiki.TEXT_SCALE);
         y = (int)(y * GuiWiki.TEXT_SCALE);
-        ItemStack inputStack = null;
-        ItemStack resultStack = null;
+        ItemStack inputStack = ItemStack.EMPTY;
+        ItemStack resultStack = ItemStack.EMPTY;
         if(arguments[2].startsWith("key=")) {
             String resultStackCode = arguments[2].substring(4);
             inputStack = autoMappedFurnaceRecipes.get(resultStackCode);
-            if(inputStack != null) {
+            if(!inputStack.isEmpty()) {
                 resultStack = WikiUtils.getStackFromName(resultStackCode);
             } else {
                 FurnaceRetrievalEvent recipeEvent = new FurnaceRetrievalEvent(resultStackCode);
@@ -62,10 +62,10 @@ public class IntegratorFurnace implements IRecipeIntegrator{
             inputStack = WikiUtils.getStackFromName(arguments[2]);
             resultStack = WikiUtils.getStackFromName(arguments[3]);
         }
-        if(inputStack != null) {
+        if(!inputStack.isEmpty()) {
             locatedStacks.add(new LocatedStack(inputStack, x + IntegratorCraftingRecipe.STACKS_X_OFFSET, y + IntegratorCraftingRecipe.STACKS_Y_OFFSET));
         }
-        if(resultStack != null) {
+        if(!resultStack.isEmpty()) {
             locatedStacks.add(new LocatedStack(resultStack, x + IntegratorCraftingRecipe.STACKS_X_OFFSET + 60, y + IntegratorCraftingRecipe.STACKS_Y_OFFSET + 18));
         }
     }

--- a/src/igwmod/recipeintegration/IntegratorStack.java
+++ b/src/igwmod/recipeintegration/IntegratorStack.java
@@ -35,7 +35,7 @@ public class IntegratorStack implements IRecipeIntegrator{
         }
 
         ItemStack stack = WikiUtils.getStackFromName(arguments[2]);
-        if(stack == null) throw new IllegalArgumentException("Item not found for the name " + arguments[2]);
+        if(stack.isEmpty()) throw new IllegalArgumentException("Item not found for the name " + arguments[2]);
         locatedStacks.add(new LocatedStack(stack, (int)(x * GuiWiki.TEXT_SCALE), (int)(y * GuiWiki.TEXT_SCALE)));
     }
 


### PR DESCRIPTION
As of MC1.11, ItemStack.EMPTY should always be used instead of 'null'.

This specifically fixes an interaction problem with the Item Scroller mod, where rolling the mouse wheel over a container slot in the wiki crashes the client.

Longer term I'd recommend going through any methods which take or return an ItemStack and annotating those parameters & returns with ``@Nonnull``, but this PR will fix any immediate problems.