### PR TITLE
Call drawDefaultBackground() in GuiWiki#drawScreen()

### DIFF
--- a/src/igwmod/gui/GuiWiki.java
+++ b/src/igwmod/gui/GuiWiki.java
@@ -395,6 +395,7 @@ public class GuiWiki extends GuiContainer{
      */
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks){
+        drawDefaultBackground();
         lastMouseX = mouseX;
         boolean leftClicking = Mouse.isButtonDown(0);
         int pageLinkScrollX1 = guiLeft + PAGE_LINK_SCROLL_X;


### PR DESCRIPTION
Needed to darken down the background while the IGW gui is open, in common with all other GUIs.