### PR TITLE
A couple of small build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ archivesBaseName = "IGW-Mod"
 if (System.getenv().BUILD_NUMBER != null) {
     version += "-${System.getenv().BUILD_NUMBER}"
 } else {
-    version += " - err"
+    version += "-err"
 }
 
 def grabDep(url) {
@@ -125,7 +125,7 @@ processResources
         include 'mcmod.info'
                 
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version':version, 'mcversion':project.minecraft.version
     }
         
     // copy everything else, thats not the mcmod.info

--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -8,7 +8,7 @@
   "url": "www.minemaarten.com",
   "updateUrl": "",
   "authorList": [
-    "MineMaarten";)"
+    "MineMaarten"
   ],
   "screenshots": [
   ],


### PR DESCRIPTION
* Removed spurious characters from mcmod.info (caused invalid JSON)
* Substitute the proper mod version string into mcmod.info

This specifically fixes a problem where specifying version dependencies
in ``@Mod`` annotations doesn't work.  E.g. PNC:R should require a version
of IGW >= 1.4.1-10 (at this time) due to the API changes, but I can't
enforce that without this fix.